### PR TITLE
Dockerizing segvan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM gcc:7
+RUN git clone https://github.com/nym-zone/segvan && \
+  cd segvan && \
+  make
+ENV PATH /segvan:$PATH

--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ By nullius <[nullius@nym.zone](nullius@nym.zone)> ([PGP ECC](https://sks-keyserv
 
 This is an early release of something I more or less whipped up off-the-cuff in December.  It will be improved and documented.  Yes, it will have a manpage (currently half-written).
 
+## Docker
+
+To build the container locally run:
+
+```
+docker build -t segvan .
+```
+
+After the container is built you may run:
+
+```
+docker run -ti segvan segvan -R Test
+```
+
 Development may be encouraged by tips sent to these sample products of this program:
 
 - [bc1q**nullnym**efa273hgss63kvtvr0q7377kjza0607](bitcoin:bc1qnullnymefa273hgss63kvtvr0q7377kjza0607)


### PR DESCRIPTION
This PR adds docker to `segvan`. The idea behind this is that an image can be pushed to docker hub and a user could simply pull down the image and not have to worry about installation. Instructions have been added to `README.md`.